### PR TITLE
Pull 0.2.1 from crates.io

### DIFF
--- a/aspect-weave/Cargo.toml
+++ b/aspect-weave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aspect-weave"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Simon Chemouil <simon.chemouil@lambdacube.fr>"]
 license = "Apache-2.0 OR MIT"
 readme = "../README.md"
@@ -16,5 +16,5 @@ edition = "2018"
 syn = {version= "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-indexmap = "1.1"
-synattra = "0.2.0"
+indexmap = "1.6"
+synattra = "0.2"

--- a/aspect/Cargo.toml
+++ b/aspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aspect"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Simon Chemouil <simon.chemouil@lambdacube.fr>"]
 license = "Apache-2.0 OR MIT"
 readme = "../README.md"

--- a/aspect/src/lib.rs
+++ b/aspect/src/lib.rs
@@ -42,7 +42,14 @@ pub trait OnResult<R>: Enter {
     /// This function is passed both the enter return value, and the expression return value.
     ///
     /// `on_result` does not get a chance to alter the returned result. Use `OnResultMut` for that purpose.
-    fn on_result(&self, _enter: <Self as Enter>::E, _result: &R) -> Advice {
+    fn on_result(&self, enter: <Self as Enter>::E, _result: &R) -> Advice {
+        self.leave_scope(enter)
+    }
+
+    /// Called when an expression has exited, but the return value isn't known.
+    /// This can happen because of a panic, or if control flow bypasses a macro.
+    /// This is also called by the default implementation of `on_result`.
+    fn leave_scope(&self, _enter: <Self as Enter>::E) -> Advice {
         Advice::Return
     }
 }
@@ -57,4 +64,3 @@ pub trait OnResultMut<R>: Enter {
         Advice::Return
     }
 }
-

--- a/aspect/src/update.rs
+++ b/aspect/src/update.rs
@@ -19,7 +19,6 @@ impl<T, U: UpdateRef<T>> Update<T> for U {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::{Update, UpdateRef};


### PR DESCRIPTION
There's currently a mismatch between git & crates.io, so this MR is to sync this repo with what's currently published from https://crates.io/api/v1/crates/aspect/0.2.1/download & https://crates.io/api/v1/crates/aspect-weave/0.2.1/download