### PR TITLE
Add OnResultOwned

### DIFF
--- a/aspect/Cargo.toml
+++ b/aspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aspect"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Simon Chemouil <simon.chemouil@lambdacube.fr>"]
 license = "Apache-2.0 OR MIT"
 readme = "../README.md"


### PR DESCRIPTION
This is more convenient when R is a Result<T, Wrapped<E>>, since it is easy to convert that to a Result<T, E>, but it is hard to convert the respective references.